### PR TITLE
Week4

### DIFF
--- a/src/Accounting/AccountingDbContext.cs
+++ b/src/Accounting/AccountingDbContext.cs
@@ -16,6 +16,8 @@ public class AccountingDbContext : DbContext
         _logger = logger;
     }
 
+    public DbSet<Account> Accounts { get; set; }
+    public DbSet<Domain.Task> Tasks { get; set; }
     public DbSet<Popug> Pogugs { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/src/Accounting/AccountingDbContextSeeder.cs
+++ b/src/Accounting/AccountingDbContextSeeder.cs
@@ -1,5 +1,6 @@
 using Accounting.Domain;
 using Microsoft.Extensions.Options;
+using Task = System.Threading.Tasks.Task;
 
 namespace Accounting;
 

--- a/src/Accounting/Domain/Account.cs
+++ b/src/Accounting/Domain/Account.cs
@@ -1,0 +1,41 @@
+using Accounting.Domain.Events;
+
+namespace Accounting.Domain;
+
+public class Account : Entity
+{
+    private readonly List<Transaction> _transactions = new();
+
+    public Account(Popug owner)
+    {
+        Owner = owner;
+    }
+
+    public Popug Owner { get; }
+    public double Balance { get; private set; }
+    public IReadOnlyCollection<Transaction> Transactions => _transactions.AsReadOnly();
+    
+    public void Deposit(double amount, string description)
+    {
+        if (amount <= 0)
+            throw new ArgumentException(nameof(amount));
+            
+        var deposit = new Transaction(description, 0, amount);
+        _transactions.Add(deposit);
+        
+        Balance += amount;
+        _domainEvents.Add(new TransactionCommittedDomainEvent(this, deposit));
+    }
+    
+    public void Withdraw(double amount, string description)
+    {
+        if (amount <= 0)
+            throw new ArgumentException(nameof(amount));
+        
+        var withdrawal = new Transaction(description, amount, 0);
+        _transactions.Add(withdrawal);
+        
+        Balance -= amount;
+        _domainEvents.Add(new TransactionCommittedDomainEvent(this, withdrawal));
+    }
+}

--- a/src/Accounting/Domain/Events/TransactionCommittedDomainEvent.cs
+++ b/src/Accounting/Domain/Events/TransactionCommittedDomainEvent.cs
@@ -1,0 +1,13 @@
+namespace Accounting.Domain.Events;
+
+internal class TransactionCommittedDomainEvent : DomainEvent
+{
+    public TransactionCommittedDomainEvent(Account account, Transaction transaction)
+    {
+        Account = account;
+        Transaction = transaction;
+    }
+    
+    public Account Account { get; }
+    public Transaction Transaction { get; }
+}

--- a/src/Accounting/Domain/Task.cs
+++ b/src/Accounting/Domain/Task.cs
@@ -1,0 +1,9 @@
+﻿namespace Accounting.Domain;
+
+public class Task : Entity
+{
+    public string Title { get; set; }
+    public string Description { get; set; }
+    public double Fee { get; set; }
+    public double Reward { get; set; }
+}

--- a/src/Accounting/Domain/Transaction.cs
+++ b/src/Accounting/Domain/Transaction.cs
@@ -1,0 +1,15 @@
+﻿namespace Accounting.Domain;
+
+public class Transaction : Entity
+{
+    public Transaction(string description, double credit, double debit)
+    {
+        Description = description;
+        Credit = credit;
+        Debit = debit;
+    }
+
+    public string Description { get; }
+    public double Credit { get; }
+    public double Debit { get; }
+}

--- a/src/Accounting/Integration/EventConsuming/MediatrBasedMessageBrokerEventConsumer.cs
+++ b/src/Accounting/Integration/EventConsuming/MediatrBasedMessageBrokerEventConsumer.cs
@@ -1,0 +1,13 @@
+using MediatR;
+
+namespace Accounting.Integration.EventConsuming;
+
+internal abstract class MediatrBasedMessageBrokerEventConsumer<TMessageBrokerEvent> : INotificationHandler<TMessageBrokerEvent> where TMessageBrokerEvent : MessageBrokerEvent
+{
+    protected abstract Task Consume(TMessageBrokerEvent @event, CancellationToken cancellationToken);
+
+    public async Task Handle(TMessageBrokerEvent notification, CancellationToken cancellationToken)
+    {
+        await Consume(notification, cancellationToken);
+    }
+}

--- a/src/Accounting/Integration/EventConsuming/PopugCreatedStreamingEvent.cs
+++ b/src/Accounting/Integration/EventConsuming/PopugCreatedStreamingEvent.cs
@@ -1,0 +1,25 @@
+﻿using Accounting.Domain;
+
+namespace Accounting.Integration.EventConsuming;
+
+public class PopugCreatedStreamingEvent : MessageBrokerEvent
+{
+    private static readonly MessageBrokerEventName EventName = new("Users", "Created");
+    private static readonly MessageBrokerEventType EventType = MessageBrokerEventType.Streaming;
+
+    public PopugCreatedStreamingEvent(Guid id, DateTime createdAt, DataType data) : base(id, EventName, EventType, 1, createdAt, data)
+    {
+    }
+    
+    // public PopugCreatedStreamingEvent(DataType data, Guid id, MessageBrokerEventName name, int version, DateTime createdAt) : base(data, id, name, version, createdAt)
+    // {
+    // }
+
+    public class DataType
+    {
+        public Guid Id { get; set; }
+        public string Username { get; set; }
+        public string FullName { get; set; }
+        public RoleType Role { get; set; }
+    }
+}

--- a/src/Accounting/Integration/EventConsuming/PopugCreatedStreamingEventConsumer.cs
+++ b/src/Accounting/Integration/EventConsuming/PopugCreatedStreamingEventConsumer.cs
@@ -1,0 +1,23 @@
+using Accounting.Domain;
+using Task = System.Threading.Tasks.Task;
+
+namespace Accounting.Integration.EventConsuming;
+
+internal class PopugCreatedStreamingEventConsumer : MediatrBasedMessageBrokerEventConsumer<PopugCreatedStreamingEvent>
+{
+    private readonly AccountingDbContext _dbContext;
+
+    public PopugCreatedStreamingEventConsumer(AccountingDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    protected override async Task Consume(PopugCreatedStreamingEvent @event, CancellationToken cancellationToken)
+    {
+        if (@event.Data is not PopugCreatedStreamingEvent.DataType eventData)
+            throw new InvalidCastException();
+
+        _dbContext.Pogugs.Add(new Popug(eventData.Username, eventData.FullName, eventData.Role));
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Accounting/Integration/EventConsuming/TaskCompletedBehaviourEvent.cs
+++ b/src/Accounting/Integration/EventConsuming/TaskCompletedBehaviourEvent.cs
@@ -1,0 +1,17 @@
+namespace Accounting.Integration.EventConsuming;
+
+public class TaskCompletedBehaviourEvent : MessageBrokerEvent
+{
+    private static readonly MessageBrokerEventName EventName = new("Tasks", "Completed");
+    private static readonly MessageBrokerEventType EventType = MessageBrokerEventType.Behaviour;
+
+    public TaskCompletedBehaviourEvent(Guid id, DateTime createdAt, DataType data) : base(id, EventName, EventType, 1, createdAt, data)
+    {
+    }
+
+    public class DataType
+    {
+        public Guid Id { get; set; }
+        public Guid AssigneeId { get; set; }
+    }
+}

--- a/src/Accounting/Integration/EventConsuming/TaskCompletedBehaviourEventConsumer.cs
+++ b/src/Accounting/Integration/EventConsuming/TaskCompletedBehaviourEventConsumer.cs
@@ -1,0 +1,40 @@
+using Accounting.Domain;
+using Microsoft.EntityFrameworkCore;
+using Task = System.Threading.Tasks.Task;
+
+namespace Accounting.Integration.EventConsuming;
+
+internal class TaskCompletedBehaviourEventConsumer : MediatrBasedMessageBrokerEventConsumer<TaskCompletedBehaviourEvent>
+{
+    private readonly AccountingDbContext _dbContext;
+
+    public TaskCompletedBehaviourEventConsumer(AccountingDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+    
+    protected override async Task Consume(TaskCompletedBehaviourEvent @event, CancellationToken cancellationToken)
+    {
+        if (@event.Data is not TaskCompletedBehaviourEvent.DataType eventData)
+            throw new InvalidCastException();
+
+        // Find account for popug
+        
+        var account = await _dbContext.Accounts.FirstOrDefaultAsync(a => a.Owner.Id == eventData.AssigneeId, cancellationToken);
+        
+        if (account is null)
+            throw new InvalidOperationException("Account not found");
+        
+        // Get task price
+        
+        var task = await _dbContext.Tasks.FirstOrDefaultAsync(t => t.Id == eventData.Id, cancellationToken);
+        
+        if (task is null)
+            throw new InvalidOperationException("Task not found");
+
+        // Give popug reward
+        
+        account.Deposit(task.Reward, $"Reward for {eventData.Id}");
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Accounting/Integration/EventConsuming/TaskCreatedBehaviourEvent.cs
+++ b/src/Accounting/Integration/EventConsuming/TaskCreatedBehaviourEvent.cs
@@ -1,0 +1,17 @@
+﻿namespace Accounting.Integration.EventConsuming;
+
+public class TaskCreatedBehaviourEvent : MessageBrokerEvent
+{
+    private static readonly MessageBrokerEventName EventName = new("Tasks", "Created");
+    private static readonly MessageBrokerEventType EventType = MessageBrokerEventType.Behaviour;
+
+    public TaskCreatedBehaviourEvent(Guid id, DateTime createdAt, DataType data) : base(id, EventName, EventType, 1, createdAt, data)
+    {
+    }
+
+    public class DataType
+    {
+        public Guid Id { get; set; }
+        public Guid AssigneeId { get; set; }
+    }
+}

--- a/src/Accounting/Integration/EventConsuming/TaskCreatedBehaviourEventConsumer.cs
+++ b/src/Accounting/Integration/EventConsuming/TaskCreatedBehaviourEventConsumer.cs
@@ -1,0 +1,41 @@
+using Accounting.Domain;
+using Microsoft.EntityFrameworkCore;
+using Task = System.Threading.Tasks.Task;
+
+namespace Accounting.Integration.EventConsuming;
+
+internal class TaskCreatedBehaviourEventConsumer : MediatrBasedMessageBrokerEventConsumer<TaskCreatedBehaviourEvent>
+{
+    private readonly AccountingDbContext _dbContext;
+
+    public TaskCreatedBehaviourEventConsumer(AccountingDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    // TODO: Introduce Commands layer because withdrawal is duplicated in TaskReassignedHandler  
+    protected override async Task Consume(TaskCreatedBehaviourEvent @event, CancellationToken cancellationToken)
+    {
+        if (@event.Data is not TaskCreatedBehaviourEvent.DataType eventData)
+            throw new InvalidCastException();
+
+        // Find account for popug
+
+        var account = await _dbContext.Accounts.FirstOrDefaultAsync(a => a.Owner.Id == eventData.AssigneeId, cancellationToken);
+
+        if (account is null)
+            throw new InvalidOperationException("Account not found");
+
+        // Get task price
+
+        var task = await _dbContext.Tasks.FirstOrDefaultAsync(t => t.Id == eventData.Id, cancellationToken);
+
+        if (task is null)
+            throw new InvalidOperationException("Task not found");
+
+        // Take fee from popug
+
+        account.Withdraw(task.Fee, $"Fee for {eventData.Id} assigned");
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Accounting/Integration/EventConsuming/TaskCreatedStreamingEvent.cs
+++ b/src/Accounting/Integration/EventConsuming/TaskCreatedStreamingEvent.cs
@@ -1,0 +1,22 @@
+namespace Accounting.Integration.EventConsuming;
+
+public class TaskCreatedStreamingEvent : MessageBrokerEvent
+{
+    private static readonly MessageBrokerEventName EventName = new("Tasks", "Created");
+    private static readonly MessageBrokerEventType EventType = MessageBrokerEventType.Streaming;
+
+    public TaskCreatedStreamingEvent(Guid id, DateTime createdAt, DataType data) : base(id, EventName, EventType, 2, createdAt, data)
+    {
+    }
+
+    public class DataType
+    {
+        public Guid Id { get; set; }
+        public string Title { get; set; }
+        public string Description { get; set; }
+        public double Fee { get; set; }
+        public double Reward { get; set; }
+        public TaskStatus Status { get; set; }
+        public Guid AssigneeId { get; set; }
+    }
+}

--- a/src/Accounting/Integration/EventConsuming/TaskCreatedStreamingEventV2.cs
+++ b/src/Accounting/Integration/EventConsuming/TaskCreatedStreamingEventV2.cs
@@ -1,0 +1,23 @@
+namespace Accounting.Integration.EventConsuming;
+
+public class TaskCreatedStreamingEventV2 : MessageBrokerEvent
+{
+    private static readonly MessageBrokerEventName EventName = new("Tasks", "Created");
+    private static readonly MessageBrokerEventType EventType = MessageBrokerEventType.Streaming;
+
+    public TaskCreatedStreamingEventV2(Guid id, DateTime createdAt, DataType data) : base(id, EventName, EventType, 2, createdAt, data)
+    {
+    }
+
+    public class DataType
+    {
+        public Guid Id { get; set; }
+        public string JiraId { get; set; }
+        public string Title { get; set; }
+        public string Description { get; set; }
+        public double Fee { get; set; }
+        public double Reward { get; set; }
+        public string Status { get; set; }
+        public Guid AssigneeId { get; set; }
+    }
+}

--- a/src/Accounting/Integration/EventConsuming/TaskReassignedBehaviourEvent.cs
+++ b/src/Accounting/Integration/EventConsuming/TaskReassignedBehaviourEvent.cs
@@ -1,0 +1,17 @@
+namespace Accounting.Integration.EventConsuming;
+
+public class TaskReassignedBehaviourEvent : MessageBrokerEvent
+{
+    private static readonly MessageBrokerEventName EventName = new("Tasks", "Reassigned");
+    private static readonly MessageBrokerEventType EventType = MessageBrokerEventType.Behaviour;
+
+    public TaskReassignedBehaviourEvent(Guid id, DateTime createdAt, DataType data) : base(id, EventName, EventType, 1, createdAt, data)
+    {
+    }
+
+    public class DataType
+    {
+        public Guid Id { get; set; }
+        public Guid NewAssigneeId { get; set; }
+    }
+}

--- a/src/Accounting/Integration/EventConsuming/TaskReassignedBehaviourEventConsumer.cs
+++ b/src/Accounting/Integration/EventConsuming/TaskReassignedBehaviourEventConsumer.cs
@@ -1,0 +1,40 @@
+using Accounting.Domain;
+using Microsoft.EntityFrameworkCore;
+using Task = System.Threading.Tasks.Task;
+
+namespace Accounting.Integration.EventConsuming;
+
+internal class TaskReassignedBehaviourEventConsumer : MediatrBasedMessageBrokerEventConsumer<TaskReassignedBehaviourEvent>
+{
+    private readonly AccountingDbContext _dbContext;
+
+    public TaskReassignedBehaviourEventConsumer(AccountingDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+    
+    protected override async Task Consume(TaskReassignedBehaviourEvent @event, CancellationToken cancellationToken)
+    {
+        if (@event.Data is not TaskReassignedBehaviourEvent.DataType eventData)
+            throw new InvalidCastException();
+
+        // Find account for popug
+
+        var account = await _dbContext.Accounts.FirstOrDefaultAsync(a => a.Owner.Id == eventData.NewAssigneeId, cancellationToken);
+
+        if (account is null)
+            throw new InvalidOperationException("Account not found");
+
+        // Get task price
+
+        var task = await _dbContext.Tasks.FirstOrDefaultAsync(t => t.Id == eventData.Id, cancellationToken);
+
+        if (task is null)
+            throw new InvalidOperationException("Task not found");
+
+        // Take fee from popug
+
+        account.Withdraw(task.Fee, $"Fee for {eventData.Id} assigned");
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Accounting/Integration/EventProducing/TransactionCommittedBehaviourEvent.cs
+++ b/src/Accounting/Integration/EventProducing/TransactionCommittedBehaviourEvent.cs
@@ -1,0 +1,19 @@
+namespace Accounting.Integration.EventProducing;
+
+public class TransactionCommittedBehaviourEvent : MessageBrokerEvent
+{
+    private static readonly MessageBrokerEventName EventName = new("Accounts", "TransactionCommitted");
+    private static readonly MessageBrokerEventType EventType = MessageBrokerEventType.Behaviour;
+
+    public TransactionCommittedBehaviourEvent(Guid id, DateTime createdAt, DataType data) : base(id, EventName, EventType, 1, createdAt, data)
+    {
+    }
+
+    public class DataType
+    {
+        public Guid Id { get; set; }
+        public string Description { get; set; }
+        public double Credit { get; set; }
+        public double Debit { get; set; }
+    }
+}

--- a/src/Accounting/Integration/EventProducing/TransactionCommittedBehaviourEventProducer.cs
+++ b/src/Accounting/Integration/EventProducing/TransactionCommittedBehaviourEventProducer.cs
@@ -1,0 +1,24 @@
+using Accounting.Domain.Events;
+using Accounting.Integration.EventConsuming;
+
+namespace Accounting.Integration.EventProducing;
+
+internal class TransactionCommittedBehaviourEventProducer : MessageBrokerDomainEventHandler<TransactionCommittedDomainEvent, TransactionCommittedBehaviourEvent>
+{
+    public TransactionCommittedBehaviourEventProducer(IKafkaMessageProducer kafkaMessageProducer) : base(kafkaMessageProducer)
+    {
+    }
+
+    protected override TransactionCommittedBehaviourEvent MapToMessageBrokerEvent(TransactionCommittedDomainEvent domainEvent)
+    {
+        return new TransactionCommittedBehaviourEvent(Guid.NewGuid(), DateTime.UtcNow, new TransactionCommittedBehaviourEvent.DataType
+        {
+            Id = domainEvent.Transaction.Id,
+            Description = domainEvent.Transaction.Description,
+            Credit = domainEvent.Transaction.Credit,
+            Debit = domainEvent.Transaction.Debit
+        });
+    }
+
+    protected override string GetTopic() => "account-life-cycle";
+}

--- a/src/Accounting/Integration/IKafkaMessageProducer.cs
+++ b/src/Accounting/Integration/IKafkaMessageProducer.cs
@@ -1,4 +1,4 @@
-namespace TaskTracker.Integration;
+namespace Accounting.Integration;
 
 internal interface IKafkaMessageProducer : IDisposable
 {

--- a/src/Accounting/Integration/KafkaMessageProducer.cs
+++ b/src/Accounting/Integration/KafkaMessageProducer.cs
@@ -1,0 +1,43 @@
+using Accounting.Integration;
+using Confluent.Kafka;
+
+namespace TaskTracker.Integration;
+
+internal class KafkaMessageProducer : IKafkaMessageProducer
+{
+    private readonly ILogger<KafkaMessageProducer> _logger;
+    private readonly IProducer<Null, string> _producer;
+
+    public KafkaMessageProducer(ILogger<KafkaMessageProducer> logger)
+    {
+        _logger = logger;
+
+        var config = new ProducerConfig
+        {
+            BootstrapServers = "localhost:9092",
+        };
+
+        _producer = new ProducerBuilder<Null, string>(config).Build();
+    }
+
+    public async Task Produce(string topic, string message, CancellationToken cancellationToken)
+    {
+        if (topic == null) throw new ArgumentNullException(nameof(topic));
+        if (message == null) throw new ArgumentNullException(nameof(message));
+
+        var messageHash = message.GetHashCode();
+        _logger.LogInformation("Sending {Message} to {Topic} [{MessageHash}]..", topic, message, messageHash);
+
+        await _producer.ProduceAsync(topic, new Message<Null, string>
+        {
+            Value = message
+        }, cancellationToken);
+
+        _logger.LogInformation("Message [{MessageHash}] to {Topic} sent", messageHash, topic);
+    }
+
+    public void Dispose()
+    {
+        _producer.Dispose();
+    }
+}

--- a/src/Accounting/Integration/MessageBrokerDomainEventHandler.cs
+++ b/src/Accounting/Integration/MessageBrokerDomainEventHandler.cs
@@ -1,0 +1,33 @@
+﻿using System.Text.Json;
+using MediatR;
+
+namespace Accounting.Integration;
+
+internal abstract class MessageBrokerDomainEventHandler<TDomainEvent, TMessageBrokerEvent> : INotificationHandler<TDomainEvent>
+    where TDomainEvent : DomainEvent
+    where TMessageBrokerEvent : MessageBrokerEvent
+{
+    private readonly IKafkaMessageProducer _kafkaMessageProducer;
+
+    public MessageBrokerDomainEventHandler(IKafkaMessageProducer kafkaMessageProducer)
+    {
+        _kafkaMessageProducer = kafkaMessageProducer;
+    }
+
+    public async Task Handle(TDomainEvent domainEvent, CancellationToken cancellationToken)
+    {
+        if (MapToMessageBrokerEvent(domainEvent) is not { } messageBrokerEvent)
+            throw new InvalidOperationException($"Unable to map {typeof(TDomainEvent)} to {typeof(TMessageBrokerEvent)}");
+
+        // Serialize to Json and validate with Schema Registry
+        var eventJson = JsonSerializer.Serialize(messageBrokerEvent);
+
+        // TODO: Fix `Json.Schema.JsonSchemaException: Cannot resolve custom meta-schema.  Make sure meta-schemas are registered in the global registry.`
+        // SchemaRegistry.Validator.ValidateEvent(eventJson, messageBrokerEvent.Name.Domain, messageBrokerEvent.Name.Value, messageBrokerEvent.Version);
+
+        await _kafkaMessageProducer.Produce(GetTopic(), eventJson, cancellationToken);
+    }
+
+    protected abstract TMessageBrokerEvent MapToMessageBrokerEvent(TDomainEvent domainEvent);
+    protected abstract string GetTopic();
+}

--- a/src/Accounting/MessageBrokerEvent.cs
+++ b/src/Accounting/MessageBrokerEvent.cs
@@ -1,6 +1,6 @@
 ﻿using MediatR;
 
-namespace TaskTracker.Integration;
+namespace Accounting;
 
 public class MessageBrokerEvent<T> : INotification
 {

--- a/src/Accounting/MessageBrokerEventName.cs
+++ b/src/Accounting/MessageBrokerEventName.cs
@@ -1,0 +1,13 @@
+﻿namespace Accounting;
+
+public struct MessageBrokerEventName
+{
+    public MessageBrokerEventName(string domain, string value)
+    {
+        Domain = domain;
+        Value = value;
+    }
+
+    public string Value { get; }
+    public string Domain { get; }
+}

--- a/src/Accounting/MessageBrokerEventType.cs
+++ b/src/Accounting/MessageBrokerEventType.cs
@@ -1,0 +1,7 @@
+﻿namespace Accounting;
+
+public enum MessageBrokerEventType
+{
+    Streaming,
+    Behaviour
+}

--- a/src/Auth/Integration/Events/PopugCreatedStreamingEventProducer.cs
+++ b/src/Auth/Integration/Events/PopugCreatedStreamingEventProducer.cs
@@ -19,5 +19,5 @@ internal class PopugCreatedStreamingEventProducer : MessageBrokerDomainEventHand
         });
     }
 
-    protected override string GetTopic() => "popug-user-streaming";
+    protected override string GetTopic() => "user-streaming";
 }

--- a/src/TaskTracker/Domain/Popug.cs
+++ b/src/TaskTracker/Domain/Popug.cs
@@ -21,7 +21,7 @@ public class Popug : Entity
 
     public string Username { get; }
     public string FullName { get; set; }
-    public RoleType Role { get; private set; }
+    public RoleType Role { get; set; }
     public string? Email { get; init; }
     public bool IsActive { get; private set; }
 }

--- a/src/TaskTracker/Endpoints/CreateTaskEndpoint.cs
+++ b/src/TaskTracker/Endpoints/CreateTaskEndpoint.cs
@@ -44,23 +44,3 @@ public class CreateTaskEndpoint : EndpointBaseAsync.WithRequest<CreateTaskReques
         return Created($"/tasks/{task.Id}", response);
     }
 }
-
-public interface ITaskAssigneeFinder
-{
-    Task<Popug> Find(CancellationToken cancellationToken);
-}
-
-class TaskAssigneeFinder : ITaskAssigneeFinder
-{
-    private readonly TaskTrackerDbContext _taskTrackerDbContext;
-
-    public TaskAssigneeFinder(TaskTrackerDbContext taskTrackerDbContext)
-    {
-        _taskTrackerDbContext = taskTrackerDbContext;
-    }
-
-    public Task<Popug> Find(CancellationToken cancellationToken)
-    {
-        throw new NotImplementedException();
-    }
-}

--- a/src/TaskTracker/Integration/EventConsuming/MediatrBasedMessageBrokerEventConsumer.cs
+++ b/src/TaskTracker/Integration/EventConsuming/MediatrBasedMessageBrokerEventConsumer.cs
@@ -1,0 +1,13 @@
+using MediatR;
+
+namespace TaskTracker.Integration.EventConsuming;
+
+internal abstract class MediatrBasedMessageBrokerEventConsumer<TMessageBrokerEvent> : INotificationHandler<TMessageBrokerEvent> where TMessageBrokerEvent : MessageBrokerEvent
+{
+    protected abstract Task Consume(TMessageBrokerEvent @event, CancellationToken cancellationToken);
+
+    public async Task Handle(TMessageBrokerEvent notification, CancellationToken cancellationToken)
+    {
+        await Consume(notification, cancellationToken);
+    }
+}

--- a/src/TaskTracker/Integration/EventConsuming/PopugCreatedStreamingEvent.cs
+++ b/src/TaskTracker/Integration/EventConsuming/PopugCreatedStreamingEvent.cs
@@ -1,0 +1,25 @@
+﻿using TaskTracker.Domain;
+
+namespace TaskTracker.Integration.EventConsuming;
+
+public class PopugCreatedStreamingEvent : MessageBrokerEvent
+{
+    private static readonly MessageBrokerEventName EventName = new("Users", "Created");
+    private static readonly MessageBrokerEventType EventType = MessageBrokerEventType.Streaming;
+
+    public PopugCreatedStreamingEvent(Guid id, DateTime createdAt, DataType data) : base(id, EventName, EventType, 1, createdAt, data)
+    {
+    }
+    
+    // public PopugCreatedStreamingEvent(DataType data, Guid id, MessageBrokerEventName name, int version, DateTime createdAt) : base(data, id, name, version, createdAt)
+    // {
+    // }
+
+    public class DataType
+    {
+        public Guid Id { get; set; }
+        public string Username { get; set; }
+        public string FullName { get; set; }
+        public RoleType Role { get; set; }
+    }
+}

--- a/src/TaskTracker/Integration/EventConsuming/PopugCreatedStreamingEventConsumer.cs
+++ b/src/TaskTracker/Integration/EventConsuming/PopugCreatedStreamingEventConsumer.cs
@@ -1,0 +1,23 @@
+using TaskTracker.Domain;
+using Task = System.Threading.Tasks.Task;
+
+namespace TaskTracker.Integration.EventConsuming;
+
+internal class PopugCreatedStreamingEventConsumer : MediatrBasedMessageBrokerEventConsumer<PopugCreatedStreamingEvent>
+{
+    private readonly TaskTrackerDbContext _dbContext;
+
+    public PopugCreatedStreamingEventConsumer(TaskTrackerDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    protected override async Task Consume(PopugCreatedStreamingEvent @event, CancellationToken cancellationToken)
+    {
+        if (@event.Data is not PopugCreatedStreamingEvent.DataType eventData)
+            throw new InvalidCastException();
+
+        _dbContext.Popugs.Add(new Popug(eventData.Username, eventData.FullName, eventData.Role));
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/TaskTracker/Integration/EventConsuming/RoleChangedBehaviourEvent.cs
+++ b/src/TaskTracker/Integration/EventConsuming/RoleChangedBehaviourEvent.cs
@@ -1,0 +1,20 @@
+﻿using TaskTracker.Domain;
+
+namespace TaskTracker.Integration.EventConsuming;
+
+public class RoleChangedBehaviourEvent : MessageBrokerEvent
+{
+    private static readonly MessageBrokerEventName EventName = new("Users", "RoleChanged");
+    private static readonly MessageBrokerEventType EventType = MessageBrokerEventType.Behaviour;
+
+    public RoleChangedBehaviourEvent(Guid id, DateTime createdAt, DataType data) : base(id, EventName, EventType, 1, createdAt, data)
+    {
+    }
+
+    public class DataType
+    {
+        public Guid PopugId { get; }
+        public RoleType NewRole { get; }
+        public RoleType PreviousRole { get; }
+    }
+}

--- a/src/TaskTracker/Integration/EventConsuming/RoleChangedBehaviourEventConsumer.cs
+++ b/src/TaskTracker/Integration/EventConsuming/RoleChangedBehaviourEventConsumer.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace TaskTracker.Integration.EventConsuming;
+
+internal class RoleChangedBehaviourEventConsumer : MediatrBasedMessageBrokerEventConsumer<RoleChangedBehaviourEvent>
+{
+    private readonly TaskTrackerDbContext _dbContext;
+
+    public RoleChangedBehaviourEventConsumer(TaskTrackerDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+    
+    protected override async Task Consume(RoleChangedBehaviourEvent @event, CancellationToken cancellationToken)
+    {
+        if (@event.Data is not RoleChangedBehaviourEvent.DataType eventData)
+            throw new InvalidCastException();
+
+        // TODO: Handle variant when popug role changed event received before popug created event
+
+        var popug = await _dbContext.Popugs.FirstOrDefaultAsync(p => p.Id == eventData.PopugId, cancellationToken);
+
+        if (popug is null)
+            throw new InvalidOperationException("Popug not found");
+        
+        popug.Role = eventData.NewRole;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/TaskTracker/Integration/EventProducing/TaskCompletedBehaviourEvent.cs
+++ b/src/TaskTracker/Integration/EventProducing/TaskCompletedBehaviourEvent.cs
@@ -1,4 +1,4 @@
-namespace TaskTracker.Integration.Events;
+namespace TaskTracker.Integration.EventProducing;
 
 public class TaskCompletedBehaviourEvent : MessageBrokerEvent
 {

--- a/src/TaskTracker/Integration/EventProducing/TaskCompletedBehaviourEventProducer.cs
+++ b/src/TaskTracker/Integration/EventProducing/TaskCompletedBehaviourEventProducer.cs
@@ -1,0 +1,21 @@
+using TaskTracker.Domain.Events;
+
+namespace TaskTracker.Integration.EventProducing;
+
+internal class TaskCompletedBehaviourEventProducer : MessageBrokerDomainEventHandler<TaskCompletedDomainEvent, TaskCompletedBehaviourEvent>
+{
+    public TaskCompletedBehaviourEventProducer(IKafkaMessageProducer kafkaMessageProducer) : base(kafkaMessageProducer)
+    {
+    }
+
+    protected override TaskCompletedBehaviourEvent MapToMessageBrokerEvent(TaskCompletedDomainEvent domainEvent)
+    {
+        return new TaskCompletedBehaviourEvent(Guid.NewGuid(), DateTime.UtcNow, new TaskCompletedBehaviourEvent.DataType
+        {
+            Id = domainEvent.Task.Id,
+            AssigneeId = domainEvent.Task.Assignee.Id
+        });
+    }
+
+    protected override string GetTopic() => "task-life-cycle";
+}

--- a/src/TaskTracker/Integration/EventProducing/TaskCreatedBehaviourEvent.cs
+++ b/src/TaskTracker/Integration/EventProducing/TaskCreatedBehaviourEvent.cs
@@ -1,4 +1,4 @@
-﻿namespace TaskTracker.Integration.Events;
+﻿namespace TaskTracker.Integration.EventProducing;
 
 public class TaskCreatedBehaviourEvent : MessageBrokerEvent
 {
@@ -12,11 +12,6 @@ public class TaskCreatedBehaviourEvent : MessageBrokerEvent
     public class DataType
     {
         public Guid Id { get; set; }
-        public string Title { get; set; }
-        public string Description { get; set; }
-        public double Fee { get; set; }
-        public double Reward { get; set; }
-        public string Status { get; set; }
         public Guid AssigneeId { get; set; }
     }
 }

--- a/src/TaskTracker/Integration/EventProducing/TaskCreatedBehaviourEventProducer.cs
+++ b/src/TaskTracker/Integration/EventProducing/TaskCreatedBehaviourEventProducer.cs
@@ -1,6 +1,6 @@
 ﻿using TaskTracker.Domain.Events;
 
-namespace TaskTracker.Integration.Events;
+namespace TaskTracker.Integration.EventProducing;
 
 internal class TaskCreatedBehaviourEventProducer : MessageBrokerDomainEventHandler<TaskCreatedDomainEvent, TaskCreatedBehaviourEvent>
 {
@@ -13,11 +13,7 @@ internal class TaskCreatedBehaviourEventProducer : MessageBrokerDomainEventHandl
         return new TaskCreatedBehaviourEvent(Guid.NewGuid(), DateTime.UtcNow, new TaskCreatedBehaviourEvent.DataType
         {
             Id = domainEvent.Task.Id,
-            Title = domainEvent.Task.Title,
-            Description = domainEvent.Task.Description,
-            Fee = (double) domainEvent.Task.Price.Fee,
-            Reward = (double) domainEvent.Task.Price.Reward,
-            Status = domainEvent.Task.Status.ToString()
+            AssigneeId = domainEvent.Task.Assignee.Id
         });
     }
 

--- a/src/TaskTracker/Integration/EventProducing/TaskCreatedStreamingEvent.cs
+++ b/src/TaskTracker/Integration/EventProducing/TaskCreatedStreamingEvent.cs
@@ -1,0 +1,22 @@
+namespace TaskTracker.Integration.EventProducing;
+
+public class TaskCreatedStreamingEvent : MessageBrokerEvent
+{
+    private static readonly MessageBrokerEventName EventName = new("Tasks", "Created");
+    private static readonly MessageBrokerEventType EventType = MessageBrokerEventType.Streaming;
+
+    public TaskCreatedStreamingEvent(Guid id, DateTime createdAt, DataType data) : base(id, EventName, EventType, 2, createdAt, data)
+    {
+    }
+
+    public class DataType
+    {
+        public Guid Id { get; set; }
+        public string Title { get; set; }
+        public string Description { get; set; }
+        public double Fee { get; set; }
+        public double Reward { get; set; }
+        public TaskStatus Status { get; set; }
+        public Guid AssigneeId { get; set; }
+    }
+}

--- a/src/TaskTracker/Integration/EventProducing/TaskCreatedStreamingEventProducer.cs
+++ b/src/TaskTracker/Integration/EventProducing/TaskCreatedStreamingEventProducer.cs
@@ -1,0 +1,26 @@
+using TaskTracker.Domain.Events;
+
+namespace TaskTracker.Integration.EventProducing;
+
+internal class TaskCreatedStreamingEventProducer : MessageBrokerDomainEventHandler<TaskCreatedDomainEvent, TaskCreatedStreamingEvent>
+{
+    public TaskCreatedStreamingEventProducer(IKafkaMessageProducer kafkaMessageProducer) : base(kafkaMessageProducer)
+    {
+    }
+
+    protected override TaskCreatedStreamingEvent MapToMessageBrokerEvent(TaskCreatedDomainEvent domainEvent)
+    {
+        return new TaskCreatedStreamingEvent(Guid.NewGuid(), DateTime.UtcNow, new TaskCreatedStreamingEvent.DataType
+        {
+            Id = domainEvent.Task.Id,
+            AssigneeId = domainEvent.Task.Assignee.Id,
+            Title = domainEvent.Task.Title,
+            Description = domainEvent.Task.Description,
+            Fee = (double)domainEvent.Task.Price.Fee,
+            Reward = (double)domainEvent.Task.Price.Reward,
+            Status = (TaskStatus)domainEvent.Task.Status
+        });
+    }
+
+    protected override string GetTopic() => "task-streaming";
+}

--- a/src/TaskTracker/Integration/EventProducing/TaskCreatedStreamingEventV2.cs
+++ b/src/TaskTracker/Integration/EventProducing/TaskCreatedStreamingEventV2.cs
@@ -1,0 +1,23 @@
+namespace TaskTracker.Integration.EventProducing;
+
+public class TaskCreatedStreamingEventV2 : MessageBrokerEvent
+{
+    private static readonly MessageBrokerEventName EventName = new("Tasks", "Created");
+    private static readonly MessageBrokerEventType EventType = MessageBrokerEventType.Streaming;
+
+    public TaskCreatedStreamingEventV2(Guid id, DateTime createdAt, DataType data) : base(id, EventName, EventType, 2, createdAt, data)
+    {
+    }
+
+    public class DataType
+    {
+        public Guid Id { get; set; }
+        public string JiraId { get; set; }
+        public string Title { get; set; }
+        public string Description { get; set; }
+        public double Fee { get; set; }
+        public double Reward { get; set; }
+        public string Status { get; set; }
+        public Guid AssigneeId { get; set; }
+    }
+}

--- a/src/TaskTracker/Integration/EventProducing/TaskReassignedBehaviourEvent.cs
+++ b/src/TaskTracker/Integration/EventProducing/TaskReassignedBehaviourEvent.cs
@@ -1,4 +1,4 @@
-namespace TaskTracker.Integration.Events;
+namespace TaskTracker.Integration.EventProducing;
 
 public class TaskReassignedBehaviourEvent : MessageBrokerEvent
 {
@@ -13,6 +13,5 @@ public class TaskReassignedBehaviourEvent : MessageBrokerEvent
     {
         public Guid Id { get; set; }
         public Guid NewAssigneeId { get; set; }
-        public Guid PreviousAssigneeId { get; set; }
     }
 }

--- a/src/TaskTracker/Integration/EventProducing/TaskReassignedBehaviourEventProducer.cs
+++ b/src/TaskTracker/Integration/EventProducing/TaskReassignedBehaviourEventProducer.cs
@@ -1,0 +1,23 @@
+using TaskTracker.Domain.Events;
+
+namespace TaskTracker.Integration.EventProducing;
+
+internal class TaskReassignedBehaviourEventProducer : MessageBrokerDomainEventHandler<TaskReassignedDomainEvent, TaskReassignedBehaviourEvent>
+{
+    public TaskReassignedBehaviourEventProducer(IKafkaMessageProducer kafkaMessageProducer) : base(kafkaMessageProducer)
+    {
+    }
+
+    protected override TaskReassignedBehaviourEvent MapToMessageBrokerEvent(TaskReassignedDomainEvent domainEvent)
+    {
+        var lastAssigment = domainEvent.Task.Assignments.Last();
+
+        return new TaskReassignedBehaviourEvent(Guid.NewGuid(), DateTime.UtcNow, new TaskReassignedBehaviourEvent.DataType()
+        {
+            Id = domainEvent.Task.Id,
+            NewAssigneeId = lastAssigment.NewPopug.Id
+        });
+    }
+
+    protected override string GetTopic() => "task-life-cycle";
+}

--- a/src/TaskTracker/Integration/EventProducing/TaskUpdatedStreamingEvent.cs
+++ b/src/TaskTracker/Integration/EventProducing/TaskUpdatedStreamingEvent.cs
@@ -1,4 +1,4 @@
-namespace TaskTracker.Integration.Events;
+namespace TaskTracker.Integration.EventProducing;
 
 public class TaskUpdatedStreamingEvent : MessageBrokerEvent
 {

--- a/src/TaskTracker/Integration/KafkaMessageHandler.cs
+++ b/src/TaskTracker/Integration/KafkaMessageHandler.cs
@@ -1,29 +1,28 @@
+using System.Text.Json;
 using MediatR;
+using TaskTracker.Integration.EventConsuming;
 
 namespace TaskTracker.Integration;
 
 internal class KafkaMessageHandler : IKafkaMessageHandler
 {
     private readonly IPublisher _publisher;
+    private readonly IServiceScopeFactory _serviceScopeFactory;
 
-    public KafkaMessageHandler(IPublisher publisher)
+    public KafkaMessageHandler(IPublisher publisher, IServiceScopeFactory serviceScopeFactory)
     {
         _publisher = publisher;
+        _serviceScopeFactory = serviceScopeFactory;
     }
 
     public async Task Handle(string topic, string message)
     {
-        // TODO: Fix hardcoded
-        
-        await _publisher.Publish(new PopugCreatedStreamingMessage()
-        {
-            
-        });
-            
-        if (topic.Contains("-streaming"))
-        {
-            // Streaming 
-        }
-        
+        await using var scope = _serviceScopeFactory.CreateAsyncScope();
+
+        if (JsonSerializer.Deserialize(message, typeof(MessageBrokerEvent)) is not MessageBrokerEvent messageBrokerEvent)
+            throw new InvalidOperationException("Can't deserialize message to MessageBrokerEvent");
+
+        var popugCreatedStreamingEvent = (PopugCreatedStreamingEvent) messageBrokerEvent;
+        await _publisher.Publish(messageBrokerEvent);
     }
 }

--- a/src/TaskTracker/Integration/KafkaMessageListener.cs
+++ b/src/TaskTracker/Integration/KafkaMessageListener.cs
@@ -16,7 +16,7 @@ internal class KafkaMessageListener : BackgroundService
         {
             GroupId = "ates-task-tracker",
             BootstrapServers = "localhost:9092",
-            
+
             AutoOffsetReset = AutoOffsetReset.Earliest
         };
     }
@@ -32,14 +32,13 @@ internal class KafkaMessageListener : BackgroundService
             {
                 // ReSharper disable once AccessToDisposedClosure
                 var consumingTask = Task.Run(() => consumer.Consume(stoppingToken), stoppingToken);
-
-                // TODO: Prevent app crashing if problem with kafka occurs
                 var consumeResult = await consumingTask;
+
                 await _kafkaMessageHandler.Handle(consumeResult.Topic, consumeResult.Message.Value);
             }
-            catch (ConsumeException ex)
+            catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Consuming failed.");
+                _logger.LogError(ex, "Consuming message failed");
             }
         }
 

--- a/src/TaskTracker/Integration/ResilientKafkaMessageHandler.cs
+++ b/src/TaskTracker/Integration/ResilientKafkaMessageHandler.cs
@@ -1,0 +1,28 @@
+namespace TaskTracker.Integration;
+
+internal class ResilientKafkaMessageHandler : IKafkaMessageHandler
+{
+    private readonly IKafkaMessageHandler _kafkaMessageHandler;
+    private readonly ILogger<ResilientKafkaMessageHandler> _logger;
+
+    public ResilientKafkaMessageHandler(IKafkaMessageHandler kafkaMessageHandler, ILogger<ResilientKafkaMessageHandler> logger)
+    {
+        _kafkaMessageHandler = kafkaMessageHandler;
+        _logger = logger;
+    }
+
+    public async Task Handle(string topic, string message)
+    {
+        try
+        {
+            await _kafkaMessageHandler.Handle(topic, message);
+        }
+        catch (Exception ex)
+        {
+            // TODO: Ideally here must be dealing with dead letter queue (DLQ)
+            
+            // Currently just log dead message
+            _logger.LogError(ex, "Can't handle message from topic [{Topic}]: {MessageBody}", topic, message);
+        }
+    }
+}


### PR DESCRIPTION
### Текущие правки в реквесте:

- Логика Accounting с отправкой события по транзакции 
- Добавление события `TaskCreatedV2` без обработки

### Что хочется доделать:

Во всей домашке используется подход, при котором источником всех событий в системе является Domain Layer НЕ Application (как в классической реализации)!. 

Аггрегат [Task.cs](https://github.com/nomba/ates/blob/week4/src/TaskTracker/Domain/Task.cs) по действию [Reassign](https://github.com/nomba/ates/blob/b07b967714095697341c46026cb54e92f7f1ad3f/src/TaskTracker/Domain/Task.cs#L54) сохраняет события у себя и во время сохранения в БД происходит пубдикация Domain Event события в памяти [TaskReassignedDomainEvent.cs](https://github.com/nomba/ates/blob/week4/src/TaskTracker/Domain/Events/TaskReassignedDomainEvent.cs). По этому событию происходит мапинг Streaming (данные) [TaskUpdatedStreamingEvent.cs](https://github.com/nomba/ates/blob/week4/src/TaskTracker/Integration/EventProducing/TaskUpdatedStreamingEvent.cs) и Behavior (оно же бизнес-событие) [TaskReassignedBehaviourEvent.cs](https://github.com/nomba/ates/blob/week4/src/TaskTracker/Integration/EventProducing/TaskReassignedBehaviourEvent.cs)  событий для message broker. Внутрення публикация в памяти реализована с помощью MediatR (Publish/Subscribe).

До сих пор на подводные камни не наткнулся. Естественно, плата за консистентное состояние (нельзя просто так кинуть события в любом из контроллеров/сервисов) - это overhead по созданию механизма публикации.
Хочется дореализовать всю логику, плюс посмотреть как ляжет Outbox pattern в описанную концепцию, также для стриминга использовать не модели из Domain Layer, так как они должны обеспечивать инкапсуляцию, а отдельные "открытые".